### PR TITLE
Fix error `--normalize-new-line-markers`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ jobs:
           pip install --upgrade pip
           pip --verbose install poetry==1.4.1
           poetry config virtualenvs.create false
-          make install-dependencies
+          poetry install --verbose
 
       - name: Lint and test code
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - name: Print information

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Print information

--- a/Makefile
+++ b/Makefile
@@ -4,25 +4,31 @@ PYTHON_ENVIRONMENT = "whitespace_format"
 PYTHON_VERSION = "3.7.5"
 SOURCE_FILES = *.py
 
+NON_TEXT_FILES_REGEX = "\.pyc$$|\.git/|\.idea/"
+
 whitespace-format-check:
 	# Check whitespace formatting.
-	whitespace-format --check-only --color --new-line-marker linux --verbose \
+	whitespace-format --check-only --color --verbose \
+			--new-line-marker linux \
+			--normalize-new-line-markers \
 			--add-new-line-marker-at-end-of-file \
 			--remove-trailing-whitespace \
 			--remove-trailing-empty-lines \
 			--normalize-non-standard-whitespace replace \
 			--normalize-whitespace-only-files empty \
-			--exclude "\.pyc$$|\.git/|\.idea/"  .
+			--exclude $(NON_TEXT_FILES_REGEX)  .
 
 whitespace-format:
 	# Reformat code.
-	whitespace-format --color --new-line-marker linux --verbose \
+	whitespace-format --color --verbose \
+			--new-line-marker linux \
+			--normalize-new-line-markers \
 			--add-new-line-marker-at-end-of-file \
 			--remove-trailing-whitespace \
 			--remove-trailing-empty-lines \
 			--normalize-non-standard-whitespace replace \
 			--normalize-whitespace-only-files empty \
-			--exclude "\.pyc$$|^\.git/|^\.idea/"  .
+			--exclude $(NON_TEXT_FILES_REGEX)  .
 
 black-check:
 	# Check code formatting.

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PYTHON_ENVIRONMENT = "whitespace_format"
 PYTHON_VERSION = "3.7.5"
 SOURCE_FILES = *.py
 
-NON_TEXT_FILES_REGEX = "\.pyc$$|\.git/|\.idea/"
+NON_TEXT_FILES_REGEX = "\.pyc$$|\.git/|\.idea/|test_data/"
 
 whitespace-format-check:
 	# Check whitespace formatting.
@@ -92,10 +92,12 @@ create-environment:
 delete-environment:
 	# Delete virtual environment.
 	pyenv virtualenv-delete $(PYTHON_ENVIRONMENT)
+	rm -rf .python-version
 
 install-dependencies:
 	# Install all dependencies.
 	poetry install --verbose
+	pyenv rehash
 
 build-package:
 	# Build a wheel package.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "whitespace-format"
-version = "0.0.4"
+version = "0.0.5"
 description = "Linter and formatter for source code files and text files"
 license = "MIT"
 authors = ["David Pal <davidko.pal@gmail.com>"]

--- a/test_data/linux-end-of-line-markers.txt
+++ b/test_data/linux-end-of-line-markers.txt
@@ -1,0 +1,1 @@
+This is a sample text file with Linux/Unix end-of-line markers ('\n').

--- a/test_data/mac-end-of-line-markers.txt
+++ b/test_data/mac-end-of-line-markers.txt
@@ -1,0 +1,1 @@
+This is a sample text file with MacOS end-of-line markers ('\r').

--- a/test_data/windows-end-of-line-markers.txt
+++ b/test_data/windows-end-of-line-markers.txt
@@ -1,0 +1,1 @@
+This is a sample text file with Microsoft DOS/Windows end-of-line markers ('\n\r').

--- a/test_whitespace_format.py
+++ b/test_whitespace_format.py
@@ -124,24 +124,24 @@ class TestWhitespaceFormat(unittest.TestCase):
 
     def test_read_file_content_windows(self):
         """Tests read_file_content() function."""
-        content = whitespace_format.read_file_content(
+        file_content = whitespace_format.read_file_content(
             "test_data/windows-end-of-line-markers.txt", "utf-8"
         )
-        self.assertEqual(content, content.strip() + "\r\n")
+        self.assertEqual(file_content, file_content.strip() + "\r\n")
 
     def test_read_file_content_linux(self):
         """Tests read_file_content() function."""
-        content = whitespace_format.read_file_content(
+        file_content = whitespace_format.read_file_content(
             "test_data/linux-end-of-line-markers.txt", "utf-8"
         )
-        self.assertEqual(content, content.strip() + "\n")
+        self.assertEqual(file_content, file_content.strip() + "\n")
 
     def test_read_file_content_mac(self):
         """Tests read_file_content() function."""
-        content = whitespace_format.read_file_content(
+        file_content = whitespace_format.read_file_content(
             "test_data/mac-end-of-line-markers.txt", "utf-8"
         )
-        self.assertEqual(content, content.strip() + "\r")
+        self.assertEqual(file_content, file_content.strip() + "\r")
 
     def test_guess_new_end_of_line_marker(self):
         """Tests guess_new_end_of_line_marker() function."""

--- a/test_whitespace_format.py
+++ b/test_whitespace_format.py
@@ -122,6 +122,21 @@ class TestWhitespaceFormat(unittest.TestCase):
         """Verify that version numbers are the same in all places."""
         self.assertEqual(whitespace_format.VERSION, extract_version_from_pyproject())
 
+    def test_read_file_content_windows(self):
+        """Tests read_file_content() function."""
+        content = whitespace_format.read_file_content("test_data/windows-end-of-line-markers.txt", "utf-8")
+        self.assertEqual(content, content.strip() + "\r\n")
+
+    def test_read_file_content_linux(self):
+        """Tests read_file_content() function."""
+        content = whitespace_format.read_file_content("test_data/linux-end-of-line-markers.txt", "utf-8")
+        self.assertEqual(content, content.strip() + "\n")
+
+    def test_read_file_content_mac(self):
+        """Tests read_file_content() function."""
+        content = whitespace_format.read_file_content("test_data/mac-end-of-line-markers.txt", "utf-8")
+        self.assertEqual(content, content.strip() + "\r")
+
     def test_guess_new_end_of_line_marker(self):
         """Tests guess_new_end_of_line_marker() function."""
 

--- a/test_whitespace_format.py
+++ b/test_whitespace_format.py
@@ -124,17 +124,23 @@ class TestWhitespaceFormat(unittest.TestCase):
 
     def test_read_file_content_windows(self):
         """Tests read_file_content() function."""
-        content = whitespace_format.read_file_content("test_data/windows-end-of-line-markers.txt", "utf-8")
+        content = whitespace_format.read_file_content(
+            "test_data/windows-end-of-line-markers.txt", "utf-8"
+        )
         self.assertEqual(content, content.strip() + "\r\n")
 
     def test_read_file_content_linux(self):
         """Tests read_file_content() function."""
-        content = whitespace_format.read_file_content("test_data/linux-end-of-line-markers.txt", "utf-8")
+        content = whitespace_format.read_file_content(
+            "test_data/linux-end-of-line-markers.txt", "utf-8"
+        )
         self.assertEqual(content, content.strip() + "\n")
 
     def test_read_file_content_mac(self):
         """Tests read_file_content() function."""
-        content = whitespace_format.read_file_content("test_data/mac-end-of-line-markers.txt", "utf-8")
+        content = whitespace_format.read_file_content(
+            "test_data/mac-end-of-line-markers.txt", "utf-8"
+        )
         self.assertEqual(content, content.strip() + "\r")
 
     def test_guess_new_end_of_line_marker(self):

--- a/whitespace_format.py
+++ b/whitespace_format.py
@@ -22,7 +22,7 @@ from typing import Callable
 from typing import Dict
 from typing import List
 
-VERSION = "0.0.4"
+VERSION = "0.0.5"
 
 # Regular expression that does NOT match any string.
 UNMATCHABLE_REGEX = "$."
@@ -72,6 +72,14 @@ def color_print(message: str, parsed_arguments: argparse.Namespace):
     print(message)
 
 
+def string_to_hex(text: str) -> str:
+    """Converts a string into a human-readable hexadecimal representation.
+
+    This function is for debugging purposes only. It used only during development.
+    """
+    return ":".join("{:02x}".format(ord(character)) for character in text)
+
+
 def die(error_code: int, message: str = ""):
     """Exits the script."""
     if message:
@@ -82,7 +90,7 @@ def die(error_code: int, message: str = ""):
 def read_file_content(file_name: str, encoding: str) -> str:
     """Reads content of a file."""
     try:
-        with open(file_name, "r", encoding=encoding) as file:
+        with open(file_name, "r", encoding=encoding, newline="") as file:
             return file.read()
     except IOError as exception:
         die(2, f"Cannot read file '{file_name}': {exception}")
@@ -122,6 +130,13 @@ class Line:
             if line.endswith(end_of_line_marker):
                 return Line(line[: -len(end_of_line_marker)], end_of_line_marker)
         return Line(line, "")
+
+    def to_hex(self):
+        """Returns a human-readable hexadecimal representation of the line.
+
+        This function is for debugging purposes only. It used only during development.
+        """
+        return f"({string_to_hex(self.content)}, {string_to_hex(self.end_of_line_marker)})"
 
 
 def split_lines(text: str) -> List[Line]:

--- a/whitespace_format.py
+++ b/whitespace_format.py
@@ -75,7 +75,7 @@ def color_print(message: str, parsed_arguments: argparse.Namespace):
 def string_to_hex(text: str) -> str:
     """Converts a string into a human-readable hexadecimal representation.
 
-    This function is for debugging purposes only. It used only during development.
+    This function is for debugging purposes only. It is used only during development.
     """
     return ":".join(f"{ord(character):02x}" for character in text)
 
@@ -134,7 +134,7 @@ class Line:
     def to_hex(self):
         """Returns a human-readable hexadecimal representation of the line.
 
-        This function is for debugging purposes only. It used only during development.
+        This function is for debugging purposes only. It is used only during development.
         """
         return f"({string_to_hex(self.content)}, {string_to_hex(self.end_of_line_marker)})"
 

--- a/whitespace_format.py
+++ b/whitespace_format.py
@@ -77,7 +77,7 @@ def string_to_hex(text: str) -> str:
 
     This function is for debugging purposes only. It used only during development.
     """
-    return ":".join("{:02x}".format(ord(character)) for character in text)
+    return ":".join(f"{ord(character):02x}" for character in text)
 
 
 def die(error_code: int, message: str = ""):


### PR DESCRIPTION
This PR fixes a bug in `--normalize-new-line-markers` option.

The root cause of the error was in the `read_file_content()` function which called `open()` without explicitly specifying `newline` parameter. The fix is to call `open()` with `newline='""`.
