### PR TITLE
Enable ruff preview rules

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -573,31 +573,31 @@ dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments
 
 [[package]]
 name = "ruff"
-version = "0.14.1"
+version = "0.14.4"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
 files = [
-    {file = "ruff-0.14.1-py3-none-linux_armv6l.whl", hash = "sha256:083bfc1f30f4a391ae09c6f4f99d83074416b471775b59288956f5bc18e82f8b"},
-    {file = "ruff-0.14.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:f6fa757cd717f791009f7669fefb09121cc5f7d9bd0ef211371fad68c2b8b224"},
-    {file = "ruff-0.14.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d6191903d39ac156921398e9c86b7354d15e3c93772e7dbf26c9fcae59ceccd5"},
-    {file = "ruff-0.14.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed04f0e04f7a4587244e5c9d7df50e6b5bf2705d75059f409a6421c593a35896"},
-    {file = "ruff-0.14.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5c9e6cf6cd4acae0febbce29497accd3632fe2025c0c583c8b87e8dbdeae5f61"},
-    {file = "ruff-0.14.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a6fa2458527794ecdfbe45f654e42c61f2503a230545a91af839653a0a93dbc6"},
-    {file = "ruff-0.14.1-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:39f1c392244e338b21d42ab29b8a6392a722c5090032eb49bb4d6defcdb34345"},
-    {file = "ruff-0.14.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7382fa12a26cce1f95070ce450946bec357727aaa428983036362579eadcc5cf"},
-    {file = "ruff-0.14.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dd0bf2be3ae8521e1093a487c4aa3b455882f139787770698530d28ed3fbb37c"},
-    {file = "ruff-0.14.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cabcaa9ccf8089fb4fdb78d17cc0e28241520f50f4c2e88cb6261ed083d85151"},
-    {file = "ruff-0.14.1-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:747d583400f6125ec11a4c14d1c8474bf75d8b419ad22a111a537ec1a952d192"},
-    {file = "ruff-0.14.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5a6e74c0efd78515a1d13acbfe6c90f0f5bd822aa56b4a6d43a9ffb2ae6e56cd"},
-    {file = "ruff-0.14.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:0ea6a864d2fb41a4b6d5b456ed164302a0d96f4daac630aeba829abfb059d020"},
-    {file = "ruff-0.14.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:0826b8764f94229604fa255918d1cc45e583e38c21c203248b0bfc9a0e930be5"},
-    {file = "ruff-0.14.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:cbc52160465913a1a3f424c81c62ac8096b6a491468e7d872cb9444a860bc33d"},
-    {file = "ruff-0.14.1-py3-none-win32.whl", hash = "sha256:e037ea374aaaff4103240ae79168c0945ae3d5ae8db190603de3b4012bd1def6"},
-    {file = "ruff-0.14.1-py3-none-win_amd64.whl", hash = "sha256:59d599cdff9c7f925a017f6f2c256c908b094e55967f93f2821b1439928746a1"},
-    {file = "ruff-0.14.1-py3-none-win_arm64.whl", hash = "sha256:e3b443c4c9f16ae850906b8d0a707b2a4c16f8d2f0a7fe65c475c5886665ce44"},
-    {file = "ruff-0.14.1.tar.gz", hash = "sha256:1dd86253060c4772867c61791588627320abcb6ed1577a90ef432ee319729b69"},
+    {file = "ruff-0.14.4-py3-none-linux_armv6l.whl", hash = "sha256:e6604613ffbcf2297cd5dcba0e0ac9bd0c11dc026442dfbb614504e87c349518"},
+    {file = "ruff-0.14.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:d99c0b52b6f0598acede45ee78288e5e9b4409d1ce7f661f0fa36d4cbeadf9a4"},
+    {file = "ruff-0.14.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:9358d490ec030f1b51d048a7fd6ead418ed0826daf6149e95e30aa67c168af33"},
+    {file = "ruff-0.14.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:81b40d27924f1f02dfa827b9c0712a13c0e4b108421665322218fc38caf615c2"},
+    {file = "ruff-0.14.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f5e649052a294fe00818650712083cddc6cc02744afaf37202c65df9ea52efa5"},
+    {file = "ruff-0.14.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aa082a8f878deeba955531f975881828fd6afd90dfa757c2b0808aadb437136e"},
+    {file = "ruff-0.14.4-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:1043c6811c2419e39011890f14d0a30470f19d47d197c4858b2787dfa698f6c8"},
+    {file = "ruff-0.14.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a9f3a936ac27fb7c2a93e4f4b943a662775879ac579a433291a6f69428722649"},
+    {file = "ruff-0.14.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:95643ffd209ce78bc113266b88fba3d39e0461f0cbc8b55fb92505030fb4a850"},
+    {file = "ruff-0.14.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:456daa2fa1021bc86ca857f43fe29d5d8b3f0e55e9f90c58c317c1dcc2afc7b5"},
+    {file = "ruff-0.14.4-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:f911bba769e4a9f51af6e70037bb72b70b45a16db5ce73e1f72aefe6f6d62132"},
+    {file = "ruff-0.14.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:76158a7369b3979fa878612c623a7e5430c18b2fd1c73b214945c2d06337db67"},
+    {file = "ruff-0.14.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f3b8f3b442d2b14c246e7aeca2e75915159e06a3540e2f4bed9f50d062d24469"},
+    {file = "ruff-0.14.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c62da9a06779deecf4d17ed04939ae8b31b517643b26370c3be1d26f3ef7dbde"},
+    {file = "ruff-0.14.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5a443a83a1506c684e98acb8cb55abaf3ef725078be40237463dae4463366349"},
+    {file = "ruff-0.14.4-py3-none-win32.whl", hash = "sha256:643b69cb63cd996f1fc7229da726d07ac307eae442dd8974dbc7cf22c1e18fff"},
+    {file = "ruff-0.14.4-py3-none-win_amd64.whl", hash = "sha256:26673da283b96fe35fa0c939bf8411abec47111644aa9f7cfbd3c573fb125d2c"},
+    {file = "ruff-0.14.4-py3-none-win_arm64.whl", hash = "sha256:dd09c292479596b0e6fec8cd95c65c3a6dc68e9ad17b8f2382130f87ff6a75bb"},
+    {file = "ruff-0.14.4.tar.gz", hash = "sha256:f459a49fe1085a749f15414ca76f61595f1a2cc8778ed7c279b6ca2e1fd19df3"},
 ]
 
 [[package]]
@@ -757,4 +757,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.8.0"
-content-hash = "d28c4586cf6b12f7f32a17de4a12983eb63b238b1a0f981fb6465841a6c894ad"
+content-hash = "631d5c43bca1a743e704f7c7e98135915e9e270d938ed1df9dfc611d33a777b5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ pydocstyle = {extras = ["toml"], version = "^6.3.0"}
 pytest = "8.3.5"
 pylint = "^2.17.7"
 pylint-quotes = "^0.2.3"
-ruff = "^0.14.1"
+ruff = "^0.14.4"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,9 +60,12 @@ indent-style = "space"
 quote-style = "double"
 
 [tool.ruff.lint]
+preview = true
+explicit-preview-rules = false
 select = ["ALL"]
 ignore = [
     "C901",
+    "CPY001",
     "D301",
     "E501",
     "EM101",
@@ -71,6 +74,8 @@ ignore = [
     "FA100",
     "FBT001",
     "FBT003",
+    "FURB103",
+    "PLR0904",
     "PLR0912",
     "PLR0915",
     "PLR2004",
@@ -100,6 +105,10 @@ max-returns = 30
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
+
+[tool.ruff.lint.pydoclint]
+# Skip docstrings which fit on a single line.
+ignore-one-line-docstrings = true
 
 [tool.mypy]
 python_version = "3.8"

--- a/whitespace_format.py
+++ b/whitespace_format.py
@@ -259,6 +259,12 @@ def string_to_hex(text: str) -> str:
     """Converts a string into a human-readable hexadecimal representation.
 
     This function is for debugging purposes only. It is used only during development.
+
+    Args:
+        text: A string to convert to a hexadecimal representation.
+
+    Returns:
+        String where each character is replaced by a hexadecimal number.
     """
     return ":".join(f"{ord(character):02x}" for character in text)
 
@@ -274,6 +280,16 @@ def read_file_content(file_name: str, encoding: str) -> str:
     """Reads content of a file.
 
     New line markers are preserved in their original form.
+
+    If the file cannot be opened, read or decoded, the function kills the script.
+
+    Args:
+        file_name: The name of the file to read.
+        encoding: The character encoding to use.
+
+    Returns:
+        Content of the file as a string. New line markers are preserved
+        in their original form.
     """
     try:
         with open(file_name, "r", encoding=encoding, newline="") as file:
@@ -358,7 +374,7 @@ def format_file_content(
 
     # Handle an empty file.
     if not file_content:
-        if parsed_arguments.normalize_empty_files in ["ignore", "empty"]:
+        if parsed_arguments.normalize_empty_files in {"ignore", "empty"}:
             return "", []
         if parsed_arguments.normalize_empty_files == "one-line":
             return output_new_line_marker, [Change(ChangeType.REPLACED_EMPTY_FILE_WITH_ONE_LINE, 1)]
@@ -410,7 +426,7 @@ def format_file_content(
     output = ""
 
     while i < len(file_content):
-        if file_content[i] in [CARRIAGE_RETURN, LINE_FEED]:
+        if file_content[i] in {CARRIAGE_RETURN, LINE_FEED}:
             # Parse the new line marker
             new_line_marker = ""
             if file_content[i] == LINE_FEED:
@@ -508,10 +524,8 @@ def format_file_content(
                 # Remove the tab character.
                 changes.append(Change(ChangeType.REMOVED_TAB, line_number))
 
-        elif file_content[i] in [VERTICAL_TAB, FORM_FEED]:
-            if parsed_arguments.normalize_non_standard_whitespace == "ignore":
-                output += file_content[i]
-            elif parsed_arguments.normalize_non_standard_whitespace == "replace":
+        elif file_content[i] in {VERTICAL_TAB, FORM_FEED}:
+            if parsed_arguments.normalize_non_standard_whitespace == "replace":
                 output += SPACE
                 changes.append(
                     Change(
@@ -530,8 +544,8 @@ def format_file_content(
                         "",
                     ),
                 )
-            else:
-                raise ValueError("Unknown value of normalize_non_standard_whitespace")
+            else:  # parsed_arguments.normalize_non_standard_whitespace == "remove"
+                output += file_content[i]
         else:
             output += file_content[i]
             last_non_whitespace = len(output)
@@ -659,33 +673,43 @@ def reformat_files(file_names: List[str], parsed_arguments: argparse.Namespace) 
         color_print(message, parsed_arguments)
 
 
-def find_all_files_recursively(file_name: str, follow_symlinks: bool) -> List[str]:
+def find_all_files_recursively(file_or_directory_path: str, follow_symlinks: bool) -> List[str]:
     """Finds files in directories recursively."""
-    if (not follow_symlinks) and pathlib.Path(file_name).is_symlink():
+    if (not follow_symlinks) and pathlib.Path(file_or_directory_path).is_symlink():
         return []
 
-    if pathlib.Path(file_name).is_file():
-        return [file_name]
+    if pathlib.Path(file_or_directory_path).is_file():
+        return [file_or_directory_path]
 
-    if pathlib.Path(file_name).is_dir():
+    if pathlib.Path(file_or_directory_path).is_dir():
         return [
             expanded_file_name
-            for inner_file in sorted(pathlib.Path(file_name).iterdir())
+            for inner_file in sorted(pathlib.Path(file_or_directory_path).iterdir())
             for expanded_file_name in find_all_files_recursively(str(inner_file), follow_symlinks)
         ]
 
     return []
 
 
-def find_files_to_process(file_names: List[str], parsed_arguments: argparse.Namespace) -> List[str]:
+def find_files_to_process(
+    file_or_directory_paths: List[str],
+    parsed_arguments: argparse.Namespace,
+) -> List[str]:
     """Finds files that need to be processed.
 
-    The function excludes files that match the regular expression specified
-    by the "--exclude" command line option.
+    Args:
+        file_or_directory_paths: List of paths of files or directories.
+        parsed_arguments: Parsed command line arguments.
+            The function excludes file paths that match the regular expression specified
+            by the "--exclude" command line option. The symbolic links are followed
+            only if "--follow-symlinks" is set.
+
+    Returns:
+        List of paths of files that need to be processed.
     """
     return [
         expanded_file_name
-        for file_name in file_names
+        for file_name in file_or_directory_paths
         for expanded_file_name in find_all_files_recursively(
             file_name,
             parsed_arguments.follow_symlinks,
@@ -792,7 +816,7 @@ def parse_command_line() -> argparse.Namespace:
         help=(
             "Make new line markers consistent in each file "
             "by replacing '\\r\\n', '\\n', and `\\r` with a consistent new line marker. "
-            "The new line marker in the output is specified by `--new-line-marker` option. "
+            "The new line marker in the output is specified by --new-line-marker option. "
             "This option works even if the input contains an arbitrary mix of new line markers "
             "'\\r\\n', '\\n', '\\r' even within the same input file."
         ),
@@ -902,8 +926,14 @@ def parse_command_line() -> argparse.Namespace:
         choices=["ignore", "remove", "replace"],
     )
     parser.add_argument(
-        "input_files",
-        help="List of input files",
+        "input_files_or_directories",
+        help=(
+            "List of input files or directories. "
+            "Directories are recursively searched for files. "
+            "Files can be excluded --exclude option. "
+            "By default symbolic links are ignored. "
+            "They can enabled with --follow-symlinks option."
+        ),
         nargs="+",
         default=[],
         type=str,
@@ -924,7 +954,10 @@ def parse_command_line() -> argparse.Namespace:
 def main() -> None:
     """Formats white space in text files."""
     parsed_arguments = parse_command_line()
-    file_names = find_files_to_process(parsed_arguments.input_files, parsed_arguments)
+    file_names = find_files_to_process(
+        parsed_arguments.input_files_or_directories,
+        parsed_arguments,
+    )
     reformat_files(file_names, parsed_arguments)
 
 

--- a/whitespace_format.py
+++ b/whitespace_format.py
@@ -709,9 +709,9 @@ def find_files_to_process(
     """
     return [
         expanded_file_name
-        for file_name in file_or_directory_paths
+        for file_or_directory_path in file_or_directory_paths
         for expanded_file_name in find_all_files_recursively(
-            file_name,
+            file_or_directory_path,
             parsed_arguments.follow_symlinks,
         )
         if not re.search(parsed_arguments.exclude, expanded_file_name)

--- a/whitespace_format.py
+++ b/whitespace_format.py
@@ -930,9 +930,9 @@ def parse_command_line() -> argparse.Namespace:
         help=(
             "List of input files or directories. "
             "Directories are recursively searched for files. "
-            "Files can be excluded --exclude option. "
+            "Files can be excluded with --exclude option. "
             "By default symbolic links are ignored. "
-            "They can enabled with --follow-symlinks option."
+            "Use --follow-symlinks option to enable them."
         ),
         nargs="+",
         default=[],


### PR DESCRIPTION
1. Enable ruff preview rules
2. Improve docstrings
3. Use sets instead of lists
4. Remove pointless raise
5. Rename function parameters and variables
